### PR TITLE
Add hyperparameters for BC on benchmark environments

### DIFF
--- a/benchmark_results.md
+++ b/benchmark_results.md
@@ -1,5 +1,5 @@
-| Environment    | Method              | AER              | Performance     |
-|----------------|---------------------|------------------|-----------------|
-| CartPole-v1    | Behavioural Cloning | 500.0 ± 0.0      | 1.0 ± 0.0       |
-| MountainCar-v0 | Behavioural Cloning | -100.95 ± 8.2612 | 0.9789 ± 0.0816 |
-| Acrobot-v1     | Behavioural Cloning | -75.94 ± 10.6253 | 0.9858 ± 0.0248 |
+| Environment    | Method              | AER              | Performance    |
+|----------------|---------------------|------------------|----------------|
+| CartPole-v1    | Behavioural Cloning | 500.0 ± 0.0      | 1.0 ± 0.0      |
+| MountainCar-v0 | Behavioural Cloning | -101.75 ± 8.1626 | 0.971 ± 0.0807 |
+| Acrobot-v1     | Behavioural Cloning | -77.14 ± 21.0485 | 0.983 ± 0.0491 |

--- a/development/__init__.py
+++ b/development/__init__.py
@@ -1,0 +1,7 @@
+"""Setup a path to the src folder."""
+import sys
+import pathlib
+
+PACKAGE_PARENT = pathlib.Path(__file__).parent
+SCRIPT_DIR = PACKAGE_PARENT / "src"
+sys.path.append(str(SCRIPT_DIR))

--- a/development/find_lr.py
+++ b/development/find_lr.py
@@ -1,0 +1,86 @@
+import sys
+import numpy as np
+import torch
+from torch import nn, optim
+from torch.utils.data import Dataset
+from torch.utils.data import DataLoader
+from torch_lr_finder import LRFinder
+
+import gymnasium as gym
+
+from imitation_datasets.dataset import BaselineDataset
+from benchmark.methods.bc import BC
+
+
+class LrFinderDataset(Dataset):
+    def __init__(self, dataset, return_cat=False):
+        super().__init__()
+        self.dataset = dataset
+        self.return_cat = return_cat
+
+    def __len__(self):
+        return len(self.dataset)
+
+    def __getitem__(self, index):
+        s, a, nS = self.dataset[index]
+        if self.return_cat:
+            return torch.cat((s[None], nS[None]), axis=1).squeeze(), a
+        else:
+            return s, a.squeeze().long()
+
+
+class LrFinderModel(BC):
+    def forward(self, input):
+        return self.policy(input).long()
+
+
+if __name__ == "__main__":
+    env_name = sys.argv[1]
+    env = gym.make(env_name)
+    bc = BC(env)
+
+    train_dataset = BaselineDataset(
+        f"NathanGavenski/{env_name}",
+        source="huggingface",
+        n_episodes=700,
+        split="train"
+    )
+    eval_dataset = BaselineDataset(
+        f"NathanGavenski/{env_name}",
+        source="huggingface",
+        n_episodes=700,
+        split="eval"
+    )
+
+    train = LrFinderDataset(train_dataset)
+    train = DataLoader(train, batch_size=2048, shuffle=True)
+    eval = LrFinderDataset(eval_dataset)
+    eval = DataLoader(eval, batch_size=2048, shuffle=True)
+
+    model = LrFinderModel(env)
+
+    criterion = nn.CrossEntropyLoss()
+    optimizer = optim.Adam(bc.policy.parameters(), lr=1e-4)
+    lr_finder = LRFinder(
+        bc.policy,
+        optimizer,
+        criterion,
+        device="cuda" if torch.cuda.is_available() else "cpu"
+    )
+
+    # The paper proposes using between 2 and 8 epochs
+    iterations = len(train) * 8
+
+    lr_finder.reset()
+    lr_finder.range_test(
+        train,
+        val_loader=eval,
+        end_lr=5e-3,
+        num_iter=iterations,
+        step_mode="linear"
+    )
+
+    (_, lrs), (_, losses) = lr_finder.history.items()
+    min_grad_idx = (np.gradient(np.array(losses))).argmin()
+    with open(f"./{env_name}.txt", "w") as _file:
+        _file.write(f"{env_name}: {lrs[min_grad_idx]}")

--- a/requirements/benchmark.txt
+++ b/requirements/benchmark.txt
@@ -2,3 +2,4 @@ torchvision
 tensorboard-wrapper
 tensorboard
 tabulate
+pyyaml

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -7,4 +7,4 @@ pylint
 pytest-asyncio
 build
 twine
-bumpver
+torch_lr_finder

--- a/src/benchmark/benchmark.py
+++ b/src/benchmark/benchmark.py
@@ -50,7 +50,7 @@ def benchmark_method(
             performance (Dict[str, str]) performance.
     """
     policy: Method = method(environment, verbose=True, enjoy_criteria=100)
-    metrics = policy.train(1000, train_dataset=dataloader) \
+    metrics = policy.train(5000, train_dataset=dataloader) \
         .load() \
         ._enjoy(teacher_reward=teacher_reward, random_reward=random_reward)
     aer = f"{round(metrics['aer'], 4)} ± {round(metrics['aer_std'], 4)}"
@@ -104,14 +104,14 @@ def benchmark() -> None:
                     *metrics.values()
                 ])
 
-    table = tabulate(
-        benchmark_results,
-        headers=["Environment", "Method", "AER", "Performance"],
-        tablefmt="github"
-    )
+        table = tabulate(
+            benchmark_results,
+            headers=["Environment", "Method", "AER", "Performance"],
+            tablefmt="github"
+        )
 
-    with open("./benchmark_results.md", "w", encoding="utf-8") as _file:
-        _file.write(table)
+        with open("./benchmark_results.md", "w", encoding="utf-8") as _file:
+            _file.write(table)
 
 
 if __name__ == "__main__":

--- a/src/benchmark/methods/bc.py
+++ b/src/benchmark/methods/bc.py
@@ -16,6 +16,10 @@ from tqdm import tqdm
 
 from imitation_datasets.dataset.metrics import accuracy as accuracy_fn
 from .method import Method, Metrics
+from .utils import import_hyperparameters
+
+
+CONFIG_FILE = "./src/benchmark/methods/config/bc.yaml"
 
 
 class BC(Method):
@@ -32,9 +36,14 @@ class BC(Method):
         self.environment_name = environment.spec.name
         self.save_path = f"./tmp/bc/{self.environment_name}/"
 
+        self.hyperparameters = import_hyperparameters(
+            CONFIG_FILE,
+            self.environment_name,
+        )
+
         super().__init__(
             environment,
-            {"lr": 5e-4}
+            self.hyperparameters
         )
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:

--- a/src/benchmark/methods/config/bc.yaml
+++ b/src/benchmark/methods/config/bc.yaml
@@ -1,0 +1,15 @@
+CartPole-v1:
+  lr: 4.57e-3
+  policy: 'MlpPolicy'
+
+MountainCar-v0:
+  lr: 1e-3
+  policy: 'MlpPolicy'
+
+Acrobot-v1:
+  lr: 2.33e-3 
+  policy: 'MlpPolicy'
+
+Default:
+  lr: 5e-4
+  policy: 'MlpPolicy'

--- a/src/benchmark/methods/config/bc.yaml
+++ b/src/benchmark/methods/config/bc.yaml
@@ -1,13 +1,13 @@
 CartPole-v1:
-  lr: 4.57e-3
+  lr: 6e-4 
   policy: 'MlpPolicy'
 
 MountainCar-v0:
-  lr: 1e-3
+  lr: 1.3e-3
   policy: 'MlpPolicy'
 
 Acrobot-v1:
-  lr: 2.33e-3 
+  lr: 1.6e-3 
   policy: 'MlpPolicy'
 
 Default:

--- a/src/benchmark/methods/method.py
+++ b/src/benchmark/methods/method.py
@@ -56,11 +56,13 @@ class Method(ABC):
             action_size = environment.action_space.shape[0]
             self.loss_fn = continuous_loss()
 
-        self.policy = MLP(observation_size, action_size)
+        self.policy = None
+        if environment_parameters['policy'] == 'MlpPolicy':
+            self.policy = MLP(observation_size, action_size)
 
         self.optimizer_fn = optimizer_fn(
             self.policy.parameters(),
-            **environment_parameters
+            lr=environment_parameters['lr']
         )
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:

--- a/src/benchmark/methods/utils.py
+++ b/src/benchmark/methods/utils.py
@@ -30,7 +30,7 @@ def load_hyperparameters(path: str, environment_name: str = None) -> Dict[str, A
     if environment_name is None:
         environment_name = 'Default'
 
-    with open(path, 'r', encoding='urf-8') as _file:
+    with open(path, 'r', encoding='utf-8') as _file:
         config = yaml.safe_load(_file)
 
     if environment_name not in config.keys() and 'Default' not in config.keys():

--- a/src/benchmark/methods/utils.py
+++ b/src/benchmark/methods/utils.py
@@ -1,0 +1,59 @@
+from typing import Dict, Any
+import os
+
+import yaml
+
+
+def load_hyperparameters(path: str, environment_name: str = None) -> Dict[str, Any]:
+    """Load hyperparameters from YAML file.
+
+    Args:
+        path (str): path to the YAML file.
+        environment_name (str): Entry name in YAML file. Defaults to None.
+
+    Raises:
+        FileNotFoundError: if YAML file does not exists.
+        KeyError: if environment_name and 'Default' not in YAML file.
+
+    Returns:
+        hyperparameters (Dict[str, Any]): loaded hyperparameters.
+    """
+    if not os.path.exists(path):
+        raise FileNotFoundError("%s does not exists" % path)
+
+    if environment_name is None:
+        environment_name = 'Default'
+
+    with open(path, 'r') as _file:
+        config = yaml.safe_load(_file)
+
+    if environment_name not in config.keys() and 'Default' not in config.keys():
+        raise KeyError("Default configuration missing from file at %s" % path)
+
+    return config.get(environment_name, config['Default'])
+
+
+def convert_hyperparameters(hyperparameters: Dict[str, Any]) -> Dict[str, Any]:
+    """Convert hyperparameters to correct typing.
+
+    Args:
+        hyperparameters (Dict[str, Any]): Dictionary with hyperparameters.
+
+    Returns:
+        hyperparameters (Dict[str, Any]): Dictionary with converted values.
+    """
+    hyperparameters['lr'] = float(hyperparameters['lr'])
+    return hyperparameters
+
+
+def import_hyperparameters(path: str, environment_name: str = None) -> Dict[str, Any]:
+    """Import hyperparameters from YAML file.
+
+    Args:
+        path (str): path to the YAML file.
+        environment_name (str): Entry name in YAML file. Defaults to None.
+
+    Returns:
+        hyperparameters (Dict[str, Any]): loaded hyperparameters.
+    """
+    return convert_hyperparameters(load_hyperparameters(path, environment_name))

--- a/src/benchmark/methods/utils.py
+++ b/src/benchmark/methods/utils.py
@@ -1,3 +1,9 @@
+"""Module for utility functions
+
+    load_hyperparameters: load hyperparameters from YAML file
+    convert_hyperparameters: convert string values into other typings
+    import_hyperparameters: loads and converts string values.
+"""
 from typing import Dict, Any
 import os
 
@@ -19,16 +25,16 @@ def load_hyperparameters(path: str, environment_name: str = None) -> Dict[str, A
         hyperparameters (Dict[str, Any]): loaded hyperparameters.
     """
     if not os.path.exists(path):
-        raise FileNotFoundError("%s does not exists" % path)
+        raise FileNotFoundError(f"{path} does not exists")
 
     if environment_name is None:
         environment_name = 'Default'
 
-    with open(path, 'r') as _file:
+    with open(path, 'r', encoding='urf-8') as _file:
         config = yaml.safe_load(_file)
 
     if environment_name not in config.keys() and 'Default' not in config.keys():
-        raise KeyError("Default configuration missing from file at %s" % path)
+        raise KeyError(f"Default configuration missing from file at {path}")
 
     return config.get(environment_name, config['Default'])
 


### PR DESCRIPTION
Add feature to allow different hyperparameters for each environment and default configs.

```yaml
CartPole-v1:
  lr: 4.57e-3
  policy: 'MlpPolicy'

MountainCar-v0:
  lr: 1e-3
  policy: 'MlpPolicy'

Acrobot-v1:
  lr: 2.33e-3 
  policy: 'MlpPolicy'

Default:
  lr: 5e-4
  policy: 'MlpPolicy'
```